### PR TITLE
FIX: Pan gesture of navigation controller root view ignored.

### DIFF
--- a/Src/MLNavigationController.h
+++ b/Src/MLNavigationController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface MLNavigationController : UINavigationController
+@interface MLNavigationController : UINavigationController <UIGestureRecognizerDelegate>
 
 // Enable the drag to back interaction, Defalt is YES.
 @property (nonatomic,assign) BOOL canDragBack;

--- a/Src/MLNavigationController.m
+++ b/Src/MLNavigationController.m
@@ -74,6 +74,7 @@
     
     UIPanGestureRecognizer *recognizer = [[[UIPanGestureRecognizer alloc]initWithTarget:self
                                                                                  action:@selector(paningGestureReceive:)]autorelease];
+    recognizer.delegate = self;
     [recognizer delaysTouchesBegan];
     [self.view addGestureRecognizer:recognizer];
 }
@@ -151,6 +152,13 @@
     lastScreenShotView.transform = CGAffineTransformMakeScale(scale, scale);
     blackMask.alpha = alpha;
     
+}
+
+#pragma mark - UIGestureRecognizerDelegate
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    if (self.viewControllers.count <= 1 || !self.canDragBack) return NO;
+    
+    return YES;
 }
 
 #pragma mark - Gesture Recognizer -


### PR DESCRIPTION
当UINavigationController的rootViewController.view自身有pan gesture的行为时，改成MLNavigationController后会被禁用。
此pull request修复此问题。
